### PR TITLE
herokuデプロイでのエラー修正

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -28,7 +28,7 @@ Rails.application.configure do
   # config.assets.css_compressor = :sass
 
   # 本番環境でjsファイルが圧縮されないように追記
-  config.assets.js_compressor = :uglifier
+  # config.assets.js_compressor = :uglifier
 
   # Do not fallback to assets pipeline if a precompiled asset is missed.
   config.assets.compile = false


### PR DESCRIPTION
## やったこと
403fc6b611c4ed345679015905d1a4cf1a47cacc
本番環境でjsファイルが圧縮されないように追記したコードをコメントアウトにしました。

  production.rb
  `config.assets.js_compressor = :uglifier`をコメントアウト