### PR TITLE
Boardsテーブルの作成、新規投稿フォームの作成、一覧画面に表示

### DIFF
--- a/app/controllers/boards_controller.rb
+++ b/app/controllers/boards_controller.rb
@@ -2,6 +2,9 @@ class BoardsController < ApplicationController
   def top
   end
 
+  def index
+  end
+  
   def new
   end
 end

--- a/app/controllers/boards_controller.rb
+++ b/app/controllers/boards_controller.rb
@@ -3,8 +3,25 @@ class BoardsController < ApplicationController
   end
 
   def index
+    @boards = Board.all
   end
-  
+
   def new
+    @board = Board.new
+  end
+
+  def create
+
+  end
+
+  def show
+  end
+
+  def update
+
+  end
+
+  def destroy
+
   end
 end

--- a/app/controllers/boards_controller.rb
+++ b/app/controllers/boards_controller.rb
@@ -11,6 +11,13 @@ class BoardsController < ApplicationController
   end
 
   def create
+    binding.pry
+    @board = current_user.boards.new(board_params)
+    if @board.save
+      redirect_to boards_path
+    else
+      render :new
+    end
   end
 
   def show
@@ -20,5 +27,11 @@ class BoardsController < ApplicationController
   end
 
   def destroy
+  end
+
+  private
+
+  def board_params
+    params.require(:board).permit(:title, :body)
   end
 end

--- a/app/controllers/boards_controller.rb
+++ b/app/controllers/boards_controller.rb
@@ -11,17 +11,14 @@ class BoardsController < ApplicationController
   end
 
   def create
-
   end
 
   def show
   end
 
   def update
-
   end
 
   def destroy
-
   end
 end

--- a/app/models/board.rb
+++ b/app/models/board.rb
@@ -1,0 +1,2 @@
+class Board < ApplicationRecord
+end

--- a/app/models/board.rb
+++ b/app/models/board.rb
@@ -1,2 +1,6 @@
 class Board < ApplicationRecord
+  belongs_to :user
+
+  validates :title, presence: true, length: { minimum: 5, maximum: 15 }
+  validates :body, presence: true, length: { minimum: 10, maximum: 200 }
 end

--- a/app/models/board.rb
+++ b/app/models/board.rb
@@ -2,5 +2,5 @@ class Board < ApplicationRecord
   belongs_to :user
 
   validates :title, presence: true, length: { minimum: 5, maximum: 15 }
-  validates :body, presence: true, length: { minimum: 10, maximum: 200 }
+  validates :body, presence: true, length: { minimum: 5, maximum: 200 }
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,8 @@
 class User < ApplicationRecord
   authenticates_with_sorcery!
 
+  has_many :boards, dependent: :destroy
+
   validates :name, presence: true, length: { minimum: 2, maximum: 15 }
   validates :email, presence: true, uniqueness: true
   validates :password, length: { minimum: 3 }, if: -> { new_record? || changes[:crypted_password] }

--- a/app/views/boards/index.html.erb
+++ b/app/views/boards/index.html.erb
@@ -1,0 +1,10 @@
+<div class="container">
+  <div class="row">
+    <div class=" col-md-10 offset-md-1 col-lg-8 offset-lg-2">
+      <h1>一覧画面</h1>
+      <% @boards.each do |board| %>
+        <%= board.title %>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/app/views/boards/new.html.erb
+++ b/app/views/boards/new.html.erb
@@ -1,2 +1,20 @@
-<h1>新規投稿</h1>
-<p>Find me in app/views/boards/new.html.erb</p>
+<div class="container">
+  <div class="row">
+    <div class=" col-md-10 offset-md-1 col-lg-8 offset-lg-2">
+      <h1>新規投稿フォーム</h1>
+      <%= form_with model: @board, local: true do |f| %>
+        <div class="form-group">
+          <%= f.label :title %>
+          <%= f.text_field :title, class: "form-control" %>
+        </div>
+        <div class="form-group">
+          <%= f.label :body %>
+          <%= f.text_area :body, class:"form-control" %>
+        </div>
+        <div class='text-center'>
+          <%= f.submit "投稿する", class: "btn btn-primary" %>
+        </div>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -10,10 +10,11 @@
         <a class="nav-link" href="#">使い方</a>
       </li>
       <% if logged_in? %>
+        <%= link_to "新規投稿", new_board_path %>
         <%= link_to "ログアウト", logout_path, method: :delete %>
       <% else %>
-        <%= link_to "ログイン", login_path %>
         <%= link_to "新規登録", new_user_path %>
+        <%= link_to "ログイン", login_path %>
       <% end %>
     </ul>
   </div>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -10,7 +10,7 @@
         <a class="nav-link" href="#">使い方</a>
       </li>
       <% if logged_in? %>
-        <%= link_to "ログアウト", logout_path, method: :post %>
+        <%= link_to "ログアウト", logout_path, method: :delete %>
       <% else %>
         <%= link_to "ログイン", login_path %>
         <%= link_to "新規登録", new_user_path %>

--- a/app/views/user_sessions/new.html.erb
+++ b/app/views/user_sessions/new.html.erb
@@ -16,7 +16,7 @@
         </div>
       <% end %>
       <div class='text-center'>
-        <%= link_to '登録ページへ', new_user_path %>
+        <%= link_to '新規登録ページへ', new_user_path %>
       </div>
     </div>
   </div>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -1,21 +1,26 @@
-<h1>新規登録ページ</h1>
-
-<%= form_with model: @user, local: true do |f| %>
-  <div class="form-group">
-    <%= f.label :name %>
-    <%= f.text_field :name, class: "form-control" %>
+<div class="container">
+  <div class="row">
+    <div class=" col-md-10 offset-md-1 col-lg-8 offset-lg-2">
+      <h1>ユーザ新規登録</h1>
+      <%= form_with model: @user, local: true do |f| %>
+        <div class="form-group">
+          <%= f.label :name %>
+          <%= f.text_field :name, class: "form-control" %>
+        </div>
+        <div class="form-group">
+          <%= f.label :email %>
+          <%= f.email_field :email, class: "form-control" %>
+        </div>
+        <div class="form-group">
+          <%= f.label :password %>
+          <%= f.password_field :password, class: "form-control" %>
+        </div>
+        <div class="form-group">
+          <%= f.label :password_confirmation %>
+          <%= f.password_field :password_confirmation, class: "form-control" %>
+        </div>
+        <%= f.submit "登録する", class: "btn btn-primary" %>
+      <% end %>
+    </div>
   </div>
-  <div class="form-group">
-    <%= f.label :email %>
-    <%= f.email_field :email, class: "form-control" %>
-  </div>
-  <div class="form-group">
-    <%= f.label :password %>
-    <%= f.password_field :password, class: "form-control" %>
-  </div>
-  <div class="form-group">
-    <%= f.label :password_confirmation %>
-    <%= f.password_field :password_confirmation, class: "form-control" %>
-  </div>
-  <%= f.submit "登録する", class: "btn btn-primary" %>
-<% end %>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,7 +4,7 @@ Rails.application.routes.draw do
   resources :users, only: [:new, :create]
   get '/login', to: 'user_sessions#new'
   post '/login', to: 'user_sessions#create'
-  post '/logout', to: 'user_sessions#destroy'
+  delete '/logout', to: 'user_sessions#destroy'
 
   resources :boards
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,10 +1,10 @@
 Rails.application.routes.draw do
   root 'boards#top'
 
-  resources :users, only: [:new, :create]
   get '/login', to: 'user_sessions#new'
   post '/login', to: 'user_sessions#create'
   delete '/logout', to: 'user_sessions#destroy'
 
+  resources :users, only: [:new, :create]
   resources :boards
 end

--- a/db/migrate/20211121023408_create_boards.rb
+++ b/db/migrate/20211121023408_create_boards.rb
@@ -1,0 +1,8 @@
+class CreateBoards < ActiveRecord::Migration[6.1]
+  def change
+    create_table :boards do |t|
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20211121023408_create_boards.rb
+++ b/db/migrate/20211121023408_create_boards.rb
@@ -1,7 +1,13 @@
 class CreateBoards < ActiveRecord::Migration[6.1]
   def change
     create_table :boards do |t|
-
+      t.string :title,                       null: false
+      t.text :body,                          null: false
+      t.string :song_player
+      t.string :song_title
+      t.string :artist
+      t.string :song_image
+      t.references :user, foreign_key: true, null: false
       t.timestamps
     end
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,8 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_11_21_023408) do
-
+ActiveRecord::Schema.define(version: 20_211_121_023_408) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,8 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20_211_121_023_408) do
+ActiveRecord::Schema.define(version: 2021_11_21_023408) do
+
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,23 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20_211_120_032_315) do
+ActiveRecord::Schema.define(version: 2021_11_21_023408) do
+
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "boards", force: :cascade do |t|
+    t.string "title", null: false
+    t.text "body", null: false
+    t.string "song_player"
+    t.string "song_title"
+    t.string "artist"
+    t.string "song_image"
+    t.bigint "user_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["user_id"], name: "index_boards_on_user_id"
+  end
 
   create_table "users", force: :cascade do |t|
     t.string "name", null: false
@@ -23,4 +37,6 @@ ActiveRecord::Schema.define(version: 20_211_120_032_315) do
     t.datetime "updated_at", precision: 6, null: false
     t.index ["email"], name: "index_users_on_email", unique: true
   end
+
+  add_foreign_key "boards", "users"
 end


### PR DESCRIPTION
## issue
https://github.com/wataru-pgm/Recollection_Music/issues/2 https://github.com/wataru-pgm/Recollection_Music/issues/21 https://github.com/wataru-pgm/Recollection_Music/issues/22

## やったこと
2bacda0cfcc3f8621764bdf1b4da40bccd79dae0
- rails g model Board コマンドを実行しました。

ffda120d5cb6c35209274739bccd5d298f7bc7ea
- 以下カラムを追加してrails db:migrateを実行しました。
#### 追加したカラム
   - song_player
   - song_title
   - artist
   - song_image
   - user_id（外部キー）

d4318bfc8b699f27a9642473a3447617dbd318f3
- ログアウトのメソッドをpostからdeleteに変更しました。（直感的でわかりやすい）

a48643476f146203d1876535dc65152af942bf59
- レイアウトを修正しました。

30d175c1910c53db4dec09b65942f07a0e6935e1
- boardモデルにバリデーションを付与しました。

5069807119868e8cd5f714fa1b5761989a5f9d6d
- 投稿した記事を一覧画面に表示されるようにしました。