### PR TITLE
投稿詳細ページの作成

### DIFF
--- a/app/controllers/boards_controller.rb
+++ b/app/controllers/boards_controller.rb
@@ -20,6 +20,7 @@ class BoardsController < ApplicationController
   end
 
   def show
+    @board = Board.find(params[:id])
   end
 
   def update

--- a/app/views/boards/show.html.erb
+++ b/app/views/boards/show.html.erb
@@ -1,0 +1,9 @@
+<div class="container">
+  <div class="row">
+    <div class=" col-md-10 offset-md-1 col-lg-8 offset-lg-2">
+      <h1>投稿詳細ページ</h1>
+        <%= @board.title %>
+        <%= @board.body %>
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
## issue
https://github.com/wataru-pgm/Recollection_Music/issues/25

## やったこと
- 一覧画面から記事を選択すると詳細ページを表示させるようにしました。
- タイトルと内容のみ表示（音楽は後から追加）