### PR TITLE
投稿した記事の編集・更新・削除の実装

### DIFF
--- a/app/controllers/boards_controller.rb
+++ b/app/controllers/boards_controller.rb
@@ -1,8 +1,7 @@
 class BoardsController < ApplicationController
-  before_action :ensure_board, only: %i[edit update destroy]
+  before_action :ensure_board, only: [:edit, :update, :destroy]
 
-  def top
-  end
+  def top; end
 
   def index
     @boards = Board.all
@@ -25,12 +24,9 @@ class BoardsController < ApplicationController
     @board = Board.find(params[:id])
   end
 
-  def edit
-    @board = Board.find(params[:id])
-  end
+  def edit; end
 
   def update
-    @board = Board.find(params[:id])
     if @board.update(board_params)
       redirect_to @board
     else
@@ -39,7 +35,6 @@ class BoardsController < ApplicationController
   end
 
   def destroy
-    @board = Board.find(params[:id])
     @board.destroy!
     redirect_to boards_path
   end

--- a/app/controllers/boards_controller.rb
+++ b/app/controllers/boards_controller.rb
@@ -28,6 +28,12 @@ class BoardsController < ApplicationController
   end
 
   def update
+    @board = Board.find(params[:id])
+    if @board.update(board_params)
+      redirect_to @board
+    else
+      render :edit
+    end
   end
 
   def destroy

--- a/app/controllers/boards_controller.rb
+++ b/app/controllers/boards_controller.rb
@@ -37,6 +37,9 @@ class BoardsController < ApplicationController
   end
 
   def destroy
+    @board = Board.find(params[:id])
+    @board.destroy!
+    redirect_to boards_path
   end
 
   private

--- a/app/controllers/boards_controller.rb
+++ b/app/controllers/boards_controller.rb
@@ -23,6 +23,10 @@ class BoardsController < ApplicationController
     @board = Board.find(params[:id])
   end
 
+  def edit
+    @board = Board.find(params[:id])
+  end
+
   def update
   end
 

--- a/app/controllers/boards_controller.rb
+++ b/app/controllers/boards_controller.rb
@@ -1,4 +1,6 @@
 class BoardsController < ApplicationController
+  before_action :ensure_board, only: %i[edit update destroy]
+
   def top
   end
 
@@ -46,5 +48,9 @@ class BoardsController < ApplicationController
 
   def board_params
     params.require(:board).permit(:title, :body)
+  end
+
+  def ensure_board
+    @board = current_user.boards.find(params[:id])
   end
 end

--- a/app/views/boards/edit.html.erb
+++ b/app/views/boards/edit.html.erb
@@ -1,0 +1,20 @@
+<div class="container">
+  <div class="row">
+    <div class=" col-md-10 offset-md-1 col-lg-8 offset-lg-2">
+      <h1>投稿編集</h1>
+      <%= form_with model: @board, local: true do |f| %>
+        <div class="form-group">
+          <%= f.label :title %>
+          <%= f.text_field :title, class: "form-control" %>
+        </div>
+        <div class="form-group">
+          <%= f.label :body %>
+          <%= f.text_area :body, class:"form-control" %>
+        </div>
+        <div class='text-center'>
+          <%= f.submit "更新する", class: "btn btn-primary" %>
+        </div>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/app/views/boards/show.html.erb
+++ b/app/views/boards/show.html.erb
@@ -4,6 +4,7 @@
       <h1>投稿詳細ページ</h1>
         <%= @board.title %>
         <%= @board.body %>
+        <%= link_to "編集", edit_board_path %>
     </div>
   </div>
 </div>

--- a/app/views/boards/show.html.erb
+++ b/app/views/boards/show.html.erb
@@ -4,8 +4,10 @@
       <h1>投稿詳細ページ</h1>
         <%= @board.title %>
         <%= @board.body %>
-        <%= link_to "編集", edit_board_path %>
-        <%= link_to "削除", board_path, method: :delete %>
+        <% if @board.user == current_user %>
+          <%= link_to "編集", edit_board_path %>
+          <%= link_to "削除", board_path, method: :delete %>
+        <% end %>
     </div>
   </div>
 </div>

--- a/app/views/boards/show.html.erb
+++ b/app/views/boards/show.html.erb
@@ -5,6 +5,7 @@
         <%= @board.title %>
         <%= @board.body %>
         <%= link_to "編集", edit_board_path %>
+        <%= link_to "削除", board_path, method: :delete %>
     </div>
   </div>
 </div>

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,8 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_11_21_023408) do
-
+ActiveRecord::Schema.define(version: 20_211_121_023_408) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 


### PR DESCRIPTION
## issue
https://github.com/wataru-pgm/Recollection_Music/issues/28 https://github.com/wataru-pgm/Recollection_Music/issues/30

# やったこと
85b83f6387ac96e662144179727c2996656927ef
- 投稿した記事の編集ページを作成しました。

4b5a0641f79eb9687f9b91c59e9fd10f564d5ceb
- updateアクションを作成、編集した記事を更新できるようにしました。

1813521db1a674c875c5f102a0f7e07c35880fb7
- destroyアクションを作成、投稿した記事を削除できるようにしました。

433060fd85de5c1d9f988e6cd916bafc5fd511e7
- current_userかどうかを判断するために、beforeアクションを実装しました。（編集・更新・削除する前にここで判断）

d3e5a15a6310d944347774f7159b65c421c79bdb
- コードを修正
　edit, update, destroy アクションで記述していた`@board = Board.find(params[:id])`の記述を削除 
　（beforeアクションの中でcurrent_userかどうかを判断しているため）

b035a4bbdd8eb48849e04c57bef8422eab44a322
- current_userが投稿した記事にのみ編集と削除のボタンが表示されるようにしました。