### PR TITLE
FontAwesomeとBootstrapの衝突エラー

### DIFF
--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -8,8 +8,8 @@ import Turbolinks from "turbolinks"
 import * as ActiveStorage from "@rails/activestorage"
 import "channels"
 import 'bootstrap';
-import '../stylesheets/application';
 import '@fortawesome/fontawesome-free/js/all';
+import '../stylesheets/application';
 
 require('jquery')
 

--- a/app/javascript/stylesheets/application.scss
+++ b/app/javascript/stylesheets/application.scss
@@ -17,4 +17,3 @@
 @import '~bootstrap/scss/bootstrap';
 @import "header_footer";
 @import "boards";
-@import '~@fortawesome/fontawesome-free/scss/fontawesome';


### PR DESCRIPTION
## やったこと
application.scss読み込んでいたfontawsomeを削除
削除した記述
`@import '@fortawesome/fontawesome-free/scss/fontawesome';`

## 参考記事
https://asalworld.com/1520/