### PR TITLE
ユーザ詳細ページの作成

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -12,6 +12,10 @@ class UsersController < ApplicationController
     end
   end
 
+  def show
+    @user = User.find(params[:id])
+  end
+
   private
 
   def user_params

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -14,6 +14,7 @@ class UsersController < ApplicationController
 
   def show
     @user = User.find(params[:id])
+    @boards = @user.boards
   end
 
   private

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -13,7 +13,7 @@ class UsersController < ApplicationController
   end
 
   def show
-    @user = User.find_by(id: params[:id])
+    @user = User.find(params[:id])
   end
 
   private

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -13,7 +13,7 @@ class UsersController < ApplicationController
   end
 
   def show
-    @user = User.find(params[:id])
+    @user = User.find_by(id: params[:id])
   end
 
   private

--- a/app/views/boards/show.html.erb
+++ b/app/views/boards/show.html.erb
@@ -3,7 +3,7 @@
     <div class=" col-md-10 offset-md-1 col-lg-8 offset-lg-2">
       <h1>投稿詳細ページ</h1>
       <!-- 投稿された内容 -->
-      <%= link_to "ユーザ詳細ページ", user_path %>
+      <%= link_to @board.user.name, user_path(@board.user) %>
       <%= @board.title %>
       <%= @board.body %>
       <% if @board.user == current_user %>

--- a/app/views/boards/show.html.erb
+++ b/app/views/boards/show.html.erb
@@ -3,6 +3,7 @@
     <div class=" col-md-10 offset-md-1 col-lg-8 offset-lg-2">
       <h1>投稿詳細ページ</h1>
       <!-- 投稿された内容 -->
+      <%= link_to "ユーザ詳細ページ", user_path %>
       <%= @board.title %>
       <%= @board.body %>
       <% if @board.user == current_user %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,8 +1,10 @@
 <div class="container">
   <div class="row">
     <div class=" col-md-10 offset-md-1 col-lg-8 offset-lg-2">
-      <h1>ユーザ詳細画面</h1>
-        <h1 class="font-weight-normal mt-5 mb-5"><%= @user.name %>さんのページ</h1>
+      <h1 class="font-weight-normal mt-5 mb-5"><%= @user.name %>さんの投稿一覧ページ</h1>
+      <% @boards.each do |board| %>
+        <%= link_to board.title, board_path(board) %>
+      <% end %>
     </div>
   </div>
 </div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,0 +1,8 @@
+<div class="container">
+  <div class="row">
+    <div class=" col-md-10 offset-md-1 col-lg-8 offset-lg-2">
+      <h1>ユーザ詳細画面</h1>
+      
+    </div>
+  </div>
+</div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -2,7 +2,7 @@
   <div class="row">
     <div class=" col-md-10 offset-md-1 col-lg-8 offset-lg-2">
       <h1>ユーザ詳細画面</h1>
-      
+        <h1 class="font-weight-normal mt-5 mb-5"><%= @user.name %>さんのページ</h1>
     </div>
   </div>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,7 +7,7 @@ Rails.application.routes.draw do
   post '/login', to: 'user_sessions#create'
   delete '/logout', to: 'user_sessions#destroy'
 
-  resources :users, only: [:new, :create]
+  resources :users
   resources :boards do
     resources :comments, only: [:create, :destroy], shallow: true
     resource :likes, only: [:create, :destroy]

--- a/db/migrate/20211126132609_add_image_to_user.rb
+++ b/db/migrate/20211126132609_add_image_to_user.rb
@@ -1,0 +1,5 @@
+class AddImageToUser < ActiveRecord::Migration[6.1]
+  def change
+    add_column :users, :image, :string
+  end
+end

--- a/db/migrate/20211126132609_add_image_to_user.rb
+++ b/db/migrate/20211126132609_add_image_to_user.rb
@@ -1,5 +1,0 @@
-class AddImageToUser < ActiveRecord::Migration[6.1]
-  def change
-    add_column :users, :image, :string
-  end
-end

--- a/db/migrate/20211126142723_add_profile_image_to_user.rb
+++ b/db/migrate/20211126142723_add_profile_image_to_user.rb
@@ -1,0 +1,5 @@
+class AddProfileImageToUser < ActiveRecord::Migration[6.1]
+  def change
+    add_column :users, :profile_image, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_11_26_132609) do
+ActiveRecord::Schema.define(version: 2021_11_26_142723) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -56,6 +56,7 @@ ActiveRecord::Schema.define(version: 2021_11_26_132609) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.string "image"
+    t.string "profile_image"
     t.index ["email"], name: "index_users_on_email", unique: true
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,8 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20_211_125_102_252) do
+ActiveRecord::Schema.define(version: 2021_11_26_132609) do
+
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -43,7 +44,7 @@ ActiveRecord::Schema.define(version: 20_211_125_102_252) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["board_id"], name: "index_likes_on_board_id"
-    t.index %w[user_id board_id], name: "index_likes_on_user_id_and_board_id", unique: true
+    t.index ["user_id", "board_id"], name: "index_likes_on_user_id_and_board_id", unique: true
     t.index ["user_id"], name: "index_likes_on_user_id"
   end
 
@@ -54,6 +55,7 @@ ActiveRecord::Schema.define(version: 20_211_125_102_252) do
     t.string "salt"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.string "image"
     t.index ["email"], name: "index_users_on_email", unique: true
   end
 


### PR DESCRIPTION
## 概要
ユーザーの詳細ページを作成し、そのユーザが投稿した記事の一覧ページ表示させる。

## issue
https://github.com/wataru-pgm/Recollection_Music/issues/38

## やったこと
f664f09d7f2d4a602a5cb29d6cb6c56ef1d1070c
- usersテーブルにimageカラムを追加しました。

4a2c25b8a76a44390680b686f35370f6e33c6f61
- imageカラムの名前をprofile_imageに変更しました。

67fb3dde8b6974ac17611bd38fdec16d56b10907
- 記事の詳細ページにあるユーザ名をクリックすると、ユーザ詳細ページを表示させるようにしました。

8e35a2178835e83e0e2a73e30369e963fd795b3f
- ユーザ詳細ページにその人が投稿した記事の一覧を表示