### PR TITLE
herokuデプロイエラー修正

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -132,7 +132,7 @@ GEM
     multipart-post (2.1.1)
     netrc (0.11.0)
     nio4r (2.5.8)
-    nokogiri (1.12.5-x86_64-darwin)
+    nokogiri (>= 1.8.5)
       racc (~> 1.4)
     oauth (0.5.8)
     oauth2 (1.4.7)


### PR DESCRIPTION
## やったこと
92923eb5fb6c2201b006b382855f74ae8346fe42
nokogiriのバージョンが違ってる模様なので
>= 1.8.5に合わせました。