### PR TITLE
fix: テンプレートエラー修正

### DIFF
--- a/app/views/boards/search.html.erb
+++ b/app/views/boards/search.html.erb
@@ -28,7 +28,7 @@
             <audio controls src="<%= track.preview_url %>"></audio>
           </div>
 
-          <%= link_to "追加", new_board_path(song_title: track.name, song_image: track.iamge)  %>
+          <%= link_to "追加", new_board_path %>
         <% end %>
       <% end %>
     </div>


### PR DESCRIPTION
## 発生したエラー
検索ページから新規投稿フォームに値を渡す処理をテンプレート側に書いていたが、コントローラ側で受け取る処理を書いていなかったため発生。
```
ActionView::Template::Error (undefined method `iamge' for #<RSpotify::Track:0x00007ffa1f2b6210>):
```

##  解決

issue分ける為、新規投稿ページに遷移する際に渡すパラメータを一旦削除して対応