### PR TITLE
音楽を保存機能の実装

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,2 +1,3 @@
 class ApplicationController < ActionController::Base
+  before_action :require_login
 end

--- a/app/controllers/boards_controller.rb
+++ b/app/controllers/boards_controller.rb
@@ -17,10 +17,7 @@ class BoardsController < ApplicationController
   end
 
   def new
-    @board = current_user.boards.new
-    params[:song_title]
-    params[:song_image]
-    params[:artist]
+    @board = current_user.boards.new(track_params)
   end
 
   def create
@@ -57,6 +54,10 @@ class BoardsController < ApplicationController
 
   def board_params
     params.require(:board).permit(:title, :body)
+  end
+
+  def track_params
+    params.permit(:song_title, :artist, :song_image)
   end
 
   def ensure_board

--- a/app/controllers/boards_controller.rb
+++ b/app/controllers/boards_controller.rb
@@ -1,4 +1,5 @@
 class BoardsController < ApplicationController
+  skip_before_action :require_login, only: [:top, :index]
   before_action :ensure_board, only: [:edit, :update, :destroy]
   require 'rspotify'
   RSpotify.authenticate("1569c25d55f2414988dc28a87070eaad", "57f597603979430a8c82434ac45247be")
@@ -16,7 +17,7 @@ class BoardsController < ApplicationController
   end
 
   def new
-    @board = Board.new
+    @board = current_user.boards.new
     params[:song_title]
     params[:song_image]
     params[:artist]

--- a/app/controllers/boards_controller.rb
+++ b/app/controllers/boards_controller.rb
@@ -53,7 +53,7 @@ class BoardsController < ApplicationController
   private
 
   def board_params
-    params.require(:board).permit(:title, :body)
+    params.require(:board).permit(:title, :body, :song_title, :artist, :song_image)
   end
 
   def track_params

--- a/app/controllers/user_sessions_controller.rb
+++ b/app/controllers/user_sessions_controller.rb
@@ -1,10 +1,11 @@
 class UserSessionsController < ApplicationController
+  skip_before_action :require_login
   def new; end
 
   def create
     @user = login(params[:email], params[:password])
     if @user
-      redirect_back_or_to root_path, notice: 'ログインしました！'
+      redirect_back_or_to boards_path, notice: 'ログインしました！'
     else
       render :new
     end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,6 +1,6 @@
 class UsersController < ApplicationController
   skip_before_action :require_login
-  
+
   def new
     @user = User.new
   end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,4 +1,6 @@
 class UsersController < ApplicationController
+  skip_before_action :require_login
+  
   def new
     @user = User.new
   end

--- a/app/views/boards/new.html.erb
+++ b/app/views/boards/new.html.erb
@@ -3,8 +3,6 @@
     <div class=" col-md-10 offset-md-1 col-lg-8 offset-lg-2">
       <h1>新規投稿フォーム</h1>
 
-      <%= @tracks %>
-
       <%= form_with model: @board, local: true do |f| %>
         <div class="form-group">
           <%= f.label :title %>

--- a/app/views/boards/new.html.erb
+++ b/app/views/boards/new.html.erb
@@ -3,6 +3,10 @@
     <div class=" col-md-10 offset-md-1 col-lg-8 offset-lg-2">
       <h1>新規投稿フォーム</h1>
 
+      <%= @board.song_title %>
+      <%= @board.artist %>
+      <%= image_tag(@board.song_image) %>
+
       <%= form_with model: @board, local: true do |f| %>
         <div class="form-group">
           <%= f.label :title %>

--- a/app/views/boards/new.html.erb
+++ b/app/views/boards/new.html.erb
@@ -2,12 +2,18 @@
   <div class="row">
     <div class=" col-md-10 offset-md-1 col-lg-8 offset-lg-2">
       <h1>新規投稿フォーム</h1>
-
-      <%= @board.song_title %>
-      <%= @board.artist %>
-      <%= image_tag(@board.song_image) %>
+      <div class="track">
+        <%= @board.song_title %>
+        <%= @board.artist %>
+        <%= image_tag(@board.song_image) %>
+      </div>
 
       <%= form_with model: @board, local: true do |f| %>
+        <div class="form-group">
+          <%= f.hidden_field :song_title %>
+          <%= f.hidden_field :artist %>
+          <%= f.hidden_field :song_image %>
+        </div>
         <div class="form-group">
           <%= f.label :title %>
           <%= f.text_field :title, class: "form-control" %>

--- a/app/views/boards/search.html.erb
+++ b/app/views/boards/search.html.erb
@@ -22,14 +22,14 @@
 
           <div class="track-image">
             <% track_image = track.album.images[1] %>
-            <%= image_tag(track_image["url"])%>
+            <%= image_tag(track_image["url"]) %>
           </div>
 
           <div class = "track_player">
             <audio controls src="<%= track.preview_url %>"></audio>
           </div>
 
-          <%= link_to "追加", new_board_path(song_title: track.name, artist: track.artists, song_image: track_image) %>
+          <%= link_to "追加", new_board_path(song_title: track.name, artist: track.artists.map(&:name).join, song_image: track_image["url"]) %>
 
         <% end %>
       <% end %>

--- a/app/views/boards/search.html.erb
+++ b/app/views/boards/search.html.erb
@@ -29,8 +29,8 @@
             <audio controls src="<%= track.preview_url %>"></audio>
           </div>
 
-          <%= link_to "追加", new_board_path %>
-          
+          <%= link_to "追加", new_board_path(song_title: track.name, artist: track.artists, song_image: track_image) %>
+
         <% end %>
       <% end %>
     </div>


### PR DESCRIPTION
## issue
https://github.com/wataru-pgm/Recollection_Music/issues/26

## 概要
新規投稿ページで音楽と投稿をそれぞれ保存できるようにしました。

## やったこと
e58ab8419fca3e6292c16d7ea31f066a0b83e59b　ログインしているユーザーのみが投稿可能になり、`require_login`をつけたくないところに`skip_before_action`をつけました。

a304921e25a266c9ec514fe91fa2d24c9f53f9a0　trackの情報を新規投稿ページに表示されるようにしました。

45891c14557f32f6b236a0835f100e13ff915262　投稿と音楽を一緒に保存できるようにしました。

## 確認方法
git pullして`rails s`を実行してください。

