### PR TITLE
ユーザの削除、プロフィール編集機能の実装

### DIFF
--- a/app/assets/stylesheets/profiles.scss
+++ b/app/assets/stylesheets/profiles.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the profiles controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: https://sass-lang.com/

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -1,0 +1,10 @@
+class ProfilesController < ApplicationController
+  def show
+  end
+
+  def edit
+  end
+
+  def update
+  end
+end

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -1,11 +1,9 @@
 class ProfilesController < ApplicationController
   before_action :set_user
 
-  def show
-  end
+  def show; end
 
-  def edit
-  end
+  def edit; end
 
   def update
     if @user.update(user_params)

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -1,4 +1,6 @@
 class ProfilesController < ApplicationController
+  before_action :set_user
+
   def show
   end
 
@@ -6,5 +8,20 @@ class ProfilesController < ApplicationController
   end
 
   def update
+    if @user.update(user_params)
+      redirect_to profiles_path
+    else
+      render :edit
+    end
+  end
+
+  private
+
+  def user_params
+    params.require(:user).permit(:name, :email, :password, :password_confirmation)
+  end
+
+  def set_user
+    @user = User.find(current_user.id)
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -9,7 +9,7 @@ class UsersController < ApplicationController
     @user = User.new(user_params)
     if @user.save
       auto_login(@user)
-      redirect_to boards_path
+      redirect_to boards_path, notice: "ユーザ登録しました"
     else
       render :new
     end
@@ -23,7 +23,7 @@ class UsersController < ApplicationController
   def destroy
     @user = User.find(params[:id])
     @user.destroy
-    redirect_to root_path
+    redirect_to root_path, notice: "ユーザ「#{@user.name}」を削除しました。"
   end
 
   def following

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -20,6 +20,12 @@ class UsersController < ApplicationController
     @boards = @user.boards
   end
 
+  def destroy
+    @user = User.find(params[:id])
+    @user.destroy
+    redirect_to root_path
+  end
+
   def following
     @user = User.find_by(id: params[:id])
     @users = @user.followings

--- a/app/helpers/profiles_helper.rb
+++ b/app/helpers/profiles_helper.rb
@@ -1,0 +1,2 @@
+module ProfilesHelper
+end

--- a/app/views/profiles/edit.html.erb
+++ b/app/views/profiles/edit.html.erb
@@ -1,0 +1,2 @@
+<h1>Profiles#edit</h1>
+<p>Find me in app/views/profiles/edit.html.erb</p>

--- a/app/views/profiles/edit.html.erb
+++ b/app/views/profiles/edit.html.erb
@@ -1,2 +1,10 @@
-<h1>Profiles#edit</h1>
-<p>Find me in app/views/profiles/edit.html.erb</p>
+<h1>プロフィール編集</h1>
+<%= form_with model: @user, url: profiles_path, local: true do |f| %>
+  <%= f.label :name %>
+  <%= f.text_field :name %>
+
+  <%= f.label :email %>
+  <%= f.email_field :email %>
+
+  <%= f.submit %>
+<% end %>

--- a/app/views/profiles/edit.html.erb
+++ b/app/views/profiles/edit.html.erb
@@ -1,4 +1,4 @@
-<h1>プロフィール編集</h1>
+<h1>プロフィール編集ページ</h1>
 <%= form_with model: @user, url: profiles_path, local: true do |f| %>
   <%= f.label :name %>
   <%= f.text_field :name %>

--- a/app/views/profiles/edit.html.erb
+++ b/app/views/profiles/edit.html.erb
@@ -2,9 +2,11 @@
 <%= form_with model: @user, url: profiles_path, local: true do |f| %>
   <%= f.label :name %>
   <%= f.text_field :name %>
+  <p class= "text-sm text-gray-400">例：ほげぽん</p>
 
   <%= f.label :email %>
   <%= f.email_field :email %>
+  <p class= "text-sm text-gray-400">例：music@example.com</p>
 
   <%= f.submit %>
 <% end %>

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -4,4 +4,4 @@
 <%= current_user.email %>
 
 <%= link_to "編集", edit_profiles_path %>
-<%= link_to "退会", user_path(current_user) %>
+<%= link_to "退会", user_path(current_user), method: :delete %>

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -1,0 +1,7 @@
+<h1>プロフィール詳細</h1>
+<%= "#{current_user.name}さんのプロフィールページ" %>
+<%= current_user.name %>
+<%= current_user.email %>
+
+<%= link_to "編集", edit_profiles_path %>
+<%= link_to "退会", user_path(current_user) %>

--- a/app/views/profiles/update.html.erb
+++ b/app/views/profiles/update.html.erb
@@ -1,0 +1,2 @@
+<h1>Profiles#update</h1>
+<p>Find me in app/views/profiles/update.html.erb</p>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -11,6 +11,7 @@
       </li>
       <% if logged_in? %>
         <%= link_to "新規投稿", new_board_path %>
+        <%= link_to "プロフィール", profiles_path %>
         <%= link_to "ログアウト", logout_path, method: :delete %>
       <% else %>
         <%= link_to "新規登録", new_user_path %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,6 +18,8 @@ Rails.application.routes.draw do
     end
   end
 
+  resource :profiles, only: [:show, :edit, :update]
+
   resources :boards do
     collection { get "search" }
     resources :comments, only: [:create, :destroy], shallow: true

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,7 +12,7 @@ Rails.application.routes.draw do
   get 'likes/destroy'
   root 'boards#top'
 
-  resources :users, only: [:new, :create, :show] do
+  resources :users, only: [:new, :create, :show, :destroy] do
     member do
       get :following, :follower
     end


### PR DESCRIPTION
## issue
https://github.com/wataru-pgm/Recollection_Music/issues/20

## 概要
ユーザを削除できるようにしました。
プロフィールの名前とemailを変更できるようにしました。

## やったこと
313e4d64c5b47766c84d166ceac5023b685378a2　プロフィール詳細ページを作成しました。
90f484239f0b66b1b30e5dd673045818e158f62c　プロフィール編集機能を実装しました。
052531cc26ea550660a96f26a182099166a7204d　ユーザ退会機能を実装しました。
6578fb73b6b9aba8c8c2d4c705924fe30a97bdfb　ヘッダーにプロフィールリンクを配置しました。
b711600e1fbaaab784f9cfe4f938ec11e7a0b03b　プロフィール編集ページに例文を表記しました。

## 確認方法
・作成したユーザが削除されるかを確認してください。
・プロフィールが編集できていることを確認してください。