### PR TITLE
音楽プレイヤーの音量調整

### DIFF
--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -11,8 +11,9 @@ import '@fortawesome/fontawesome-free/js/all';
 import '../stylesheets/application';
 import "../css/tailwindcss.css";
 
-require('jquery')
-require('./preview')
+require('jquery');
+require('./preview');
+require('./audio');
 
 
 Rails.start()

--- a/app/javascript/packs/audio.js
+++ b/app/javascript/packs/audio.js
@@ -1,0 +1,9 @@
+const audioVol = () => {
+  const audios = document.getElementsByClassName('vols');
+  for( let i = 0; i < audios.length; i++ ){
+    audios[i].volume = 0.2;
+  }
+}
+window.addEventListener('DOMContentLoaded' , function(){
+  audioVol();
+}, false);

--- a/app/views/boards/show.html.erb
+++ b/app/views/boards/show.html.erb
@@ -8,7 +8,7 @@
         <%= image_tag(@board.song_image) %>
       </div>
       <div class="show-song-player">
-        <audio controls src="<%= @board.song_player %>"></audio>
+        <%= audio_tag("#{@board.song_player}", controls: true, class: "vols") %>
       </div>
       <div class="show-song-title">
         <%= @board.song_title %>


### PR DESCRIPTION
## issue
https://github.com/wataru-pgm/Recollection_Music/issues/55

## 概要
音楽プレイヤーの音量がデフォルトで100%だったので20%に設定しました。

## やったこと
d5e1194ead7943e4758433b98359a63b66d01946　`audio.js`ファイルを作成して音量を調整しました。

## 確認方法
サーバを起動してください。
