### PR TITLE
Googleアナリティクスを設定とレイアウト修正

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -32,7 +32,7 @@ gem 'meta-tags'
 # Use Active Model has_secure_password
 # gem 'bcrypt', '~> 3.1.7'
 # Use Active Storage variant
-# gem 'image_processing', '~> 1.2'
+gem 'image_processing', '~> 1.2'
 
 # Reduces boot times through caching; required in config/boot.rb
 gem 'bootsnap', '>= 1.4.4', require: false

--- a/Gemfile
+++ b/Gemfile
@@ -26,6 +26,7 @@ gem 'rspotify'
 gem 'aws-sdk-s3', require: false
 gem 'mini_magick', '>= 4.9.5 '
 gem 'rails-i18n'
+gem 'meta-tags'
 
 # gem 'redis', '~> 4.0'
 # Use Active Model has_secure_password

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -137,6 +137,8 @@ GEM
     mail (2.7.1)
       mini_mime (>= 0.1.1)
     marcel (1.0.2)
+    meta-tags (2.16.0)
+      actionpack (>= 3.2.0, < 7.1)
     method_source (1.0.0)
     mime-types (3.4.1)
       mime-types-data (~> 3.2015)
@@ -312,6 +314,7 @@ DEPENDENCIES
   jbuilder (~> 2.7)
   jquery-rails
   listen (~> 3.3)
+  meta-tags
   mini_magick (>= 4.9.5)
   pg (~> 1.1)
   pry-byebug

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -120,6 +120,9 @@ GEM
       domain_name (~> 0.5)
     i18n (1.8.11)
       concurrent-ruby (~> 1.0)
+    image_processing (1.12.1)
+      mini_magick (>= 4.9.5, < 5)
+      ruby-vips (>= 2.0.17, < 3)
     jbuilder (2.11.3)
       activesupport (>= 5.0.0)
     jmespath (1.5.0)
@@ -255,6 +258,8 @@ GEM
       rack (>= 1.1)
       rubocop (>= 1.7.0, < 2.0)
     ruby-progressbar (1.11.0)
+    ruby-vips (2.1.4)
+      ffi (~> 1.12)
     ruby2_keywords (0.0.5)
     sass-rails (6.0.0)
       sassc-rails (~> 2.1, >= 2.1.1)
@@ -311,6 +316,7 @@ DEPENDENCIES
   bootsnap (>= 1.4.4)
   byebug
   font-awesome-sass (~> 5.12.0)
+  image_processing (~> 1.2)
   jbuilder (~> 2.7)
   jquery-rails
   listen (~> 3.3)

--- a/app/controllers/boards_controller.rb
+++ b/app/controllers/boards_controller.rb
@@ -1,5 +1,5 @@
 class BoardsController < ApplicationController
-  skip_before_action :require_login, only: [:top, :index]
+  skip_before_action :require_login, only: [:top, :index, :show]
   before_action :ensure_board, only: [:edit, :update, :destroy]
   require 'rspotify'
   RSpotify.authenticate(Rails.application.credentials.spotify[:client_id],

--- a/app/views/boards/_board.html.erb
+++ b/app/views/boards/_board.html.erb
@@ -5,9 +5,9 @@
       『<%= link_to board.title, "/boards/#{board.id}" %>』
     </p>
     <% if board.board_image.present? %>
-      <%= image_tag board.board_image %>
+      <%= image_tag board.board_image.variant(resize:'300x200').processed %>
     <% else %>
-      <%= image_tag '/assets/noimage.png' %>
+      <%= image_tag '/assets/noimage.png', size: '300x300' %>
     <% end %>
     <div>
       <div class="flex ml-3 justify-center">

--- a/app/views/boards/_board.html.erb
+++ b/app/views/boards/_board.html.erb
@@ -4,11 +4,13 @@
     <p class="text-xl font-bold mt-2 mb-3">
       『<%= link_to board.title, "/boards/#{board.id}" %>』
     </p>
+
     <% if board.board_image.present? %>
       <%= image_tag board.board_image.variant(resize:'300x200').processed %>
     <% else %>
       <%= image_tag '/assets/noimage.png', size: '300x300' %>
     <% end %>
+
     <div>
       <div class="flex ml-3 justify-center">
         <div class="mt-6 mb-5 w-20">

--- a/app/views/boards/edit.html.erb
+++ b/app/views/boards/edit.html.erb
@@ -1,21 +1,44 @@
-<div class="container">
-  <div class="row">
-    <div class=" col-md-10 offset-md-1 col-lg-8 offset-lg-2">
-      <h1>投稿編集</h1>
-      <%= form_with model: @board, local: true do |f| %>
+<div class="w-full min-h-screen">
+  <section class="max-w-6xl mx-auto px-4 sm:px-6 lg:px-4 py-12">
+    <div class="text-center pb-12">
+      <h1 class="font-bold text-3xl md:text-4xl lg:text-5xl font-heading text-white">
+        投稿編集ページ
+      </h1>
+    </div>
 
-        <div class="form-group">
-          <%= f.label :title %>
-          <%= f.text_field :title, class: "form-control" %>
+    <div class="w-full bg-white rounded-lg sahdow-lg p-12 flex flex-col justify-center items-center">
+      <%= form_with model: @board, local: true do |f| %>
+        <% if @board.errors.any? %>
+          <div class="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded relative" role="alert">
+            <strong class="font-bold">
+              <%= render 'shared/error_messages', object: f.object %>
+            </strong>
+          </div>
+        <% end %>
+
+        <div class="text-xl text-center font-bold mb-5">
+          <div>
+            <%= f.label :title %>
+          </div>
+          <div>
+            <%= f.text_field :title, class: "form-control mb-3 outline-black", size: "30x2" %>
+          </div>
         </div>
-        <div class="form-group">
-          <%= f.label :body %>
-          <%= f.text_area :body, class:"form-control" %>
+
+        <div class="text-xl text-center font-bold mb-5">
+          <div>
+            <%= f.label :body %>
+          </div>
+          <div>
+            <%= f.text_area :body, class: 'form-control mb-3 outline-black', size: "30x8" %>
+          </div>
         </div>
-        <div class='text-center'>
-          <%= f.submit "更新する", class: "btn btn-primary" %>
+        <div class="text-xl text-center font-bold mb-5">
+          <div>
+            <%= f.submit "更新する", class: "btn btn-primary" %>
+          </div>
         </div>
       <% end %>
     </div>
-  </div>
+  </section>
 </div>

--- a/app/views/boards/show.html.erb
+++ b/app/views/boards/show.html.erb
@@ -34,14 +34,14 @@
         </div>
 
         <div class="text-center">
-          <div class="text-4xl font-bold mb-3">
+          <div class="text-4xl font-bold mb-5">
             『<%= @board.title %>』
           </div>
           <div>
             <% if @board.board_image.present? %>
-              <%= image_tag @board.board_image %>
+              <%= image_tag @board.board_image.variant(resize:'512x300').processed, class: "mb-6" %>
             <% else %>
-              <%= image_tag '/assets/noimage.png' %>
+              <%= image_tag '/assets/noimage.png', size: '512x300', class: "mb-6" %>
             <% end %>
           </div>
           <div class="text-2xl font-bold mb-2">

--- a/app/views/boards/show.html.erb
+++ b/app/views/boards/show.html.erb
@@ -5,54 +5,60 @@
       投稿詳細ページ
     </h1>
 
-    <div class="w-full bg-white rounded-lg sahdow-lg p-12 flex flex-col justify-center items-center">
+    <div class="w-full bg-white rounded-lg sahdow-lg p-12 flex flex-col items-center">
       <!-- 投稿された内容 -->
-      <div class="text-xl font-bold text-center mx-4 mb-3">
-        <%= image_tag @board.user.image, class: "rounded-full shadow mx-auto w-20 h-20" if @board.user.image.present? %>
-        <%= link_to @board.user.name, user_path(@board.user) %>
-      </div>
-
-      <div class="mb-5">
-        <%= image_tag(@board.song_image) %>
-      </div>
-      <div class="mb-3">
-        <%= audio_tag("#{@board.song_player}", controls: true, class: "vols") %>
-      </div>
-      <p class="text-base text-gray-400 font-semibold">
-        <i class="fas fa-music"></i>
-        <%= @board.song_title %>
-      </p>
-      <p class="text-base text-gray-400 font-semibold mb-3">
-        <i class="fas fa-user-alt"></i>
-        <%= @board.artist %>
-      </p>
-
-      <div class="text-center">
+      <div class="grid grid-cols-1 lg:grid-cols-2 bg-white">
         <div>
-          <% if @board.board_image.present? %>
-            <%= image_tag @board.board_image %>
-          <% else %>
-            <%= image_tag '/assets/noimage.png' %>
-          <% end %>
+          <div>
+            <div class="text-xl justify-center font-bold flex mx-4 mb-3">
+              <%= image_tag @board.user.image, class: "rounded-full shadow w-20 h-20" if @board.user.image.present? %>
+              <div class="my-auto justify-center">
+                <%= link_to @board.user.name, user_path(@board.user) %>
+              </div>
+            </div>
+            <div class="mb-5 flex justify-center ">
+              <%= image_tag(@board.song_image) %>
+            </div>
+          </div>
+          <div class="mb-3 flex justify-center">
+            <%= audio_tag("#{@board.song_player}", controls: true, class: "vols") %>
+          </div>
+          <p class="text-base justify-center text-gray-400 font-semibold m-auto">
+            <i class="fas fa-music"></i>
+            <%= @board.song_title %>
+          </p>
+          <p class="text-md text-base justify-center text-gray-400 font-semibold mb-4">
+            <i class="fas fa-user-alt"></i>
+            <%= @board.artist %>
+          </p>
         </div>
-        <div class="text-xl font-bold mb-3">
-          <%= @board.title %>
-        </div>
-        <div class="text-xl font-bold mb-2">
-          <%= @board.body %>
-        </div>
-        <div class="flex justify-center items-center gap-2 my-3 text-xl">
-          <% if @board.user == current_user %>
-            <%= link_to "編集", edit_board_path %>
-            <%= link_to "削除", board_path, method: :delete %>
-          <% end %>
-        </div>
-      </div>
 
-      <!-- いいね！ボタン -->
-      <div class="text-xl font-semibold mb-5">
-        <div class="likes" id="js-like-<%= @board.id %>">
-          <%= render 'likes/like', board: @board %>
+        <div class="text-center">
+          <div class="text-4xl font-bold mb-3">
+            『<%= @board.title %>』
+          </div>
+          <div>
+            <% if @board.board_image.present? %>
+              <%= image_tag @board.board_image %>
+            <% else %>
+              <%= image_tag '/assets/noimage.png' %>
+            <% end %>
+          </div>
+          <div class="text-2xl font-bold mb-2">
+            <%= simple_format(@board.body) %>
+          </div>
+          <div class="flex justify-end items-center gap-2 my-3 text-xl">
+            <% if @board.user == current_user %>
+              <%= link_to "編集", edit_board_path %>
+              <%= link_to "削除", board_path, method: :delete %>
+            <% end %>
+          </div>
+          <!-- いいね！ボタン -->
+          <div class="text-2xl font-semibold mb-5">
+            <div class="likes" id="js-like-<%= @board.id %>">
+              <%= render 'likes/like', board: @board %>
+            </div>
+          </div>
         </div>
       </div>
 

--- a/app/views/comments/_comments.html.erb
+++ b/app/views/comments/_comments.html.erb
@@ -8,7 +8,7 @@
       <%= image_tag comment.user.image, class: "rounded-full shadow mx-auto w-16 h-16" if comment.user.image.present? %>
       <%= comment.user.name %>
       <div>
-        <%= comment.body %>
+        <%= simple_format(comment.body) %>
         <% if comment.user == current_user %>
           <%= link_to "削除", comment_path(comment), method: :delete, data: {confirm: "本当に削除しますか？"} %>
         <% end %>

--- a/app/views/comments/_form.html.erb
+++ b/app/views/comments/_form.html.erb
@@ -1,8 +1,8 @@
 <!-- コメント記入欄 -->
-<div class="row mb-3">
+<div class="mt-5 mb-3">
   <div class="col-lg-8 offset-lg-2">
     <%= form_with model: comment, url: [board, comment] do |f| %>
-      <%= f.text_area :body, class: 'form-control mb-3', row: 4, placeholder: 'コメントを入力' %>
+      <%= f.text_area :body, class: 'form-control mb-3 outline-black', placeholder: 'コメントを入力', size: "40x10" %>
       <%= f.submit '投稿', class: 'btn btn-primary' %>
     <% end %>
   </div>

--- a/app/views/comments/_form.html.erb
+++ b/app/views/comments/_form.html.erb
@@ -2,7 +2,7 @@
 <div class="mt-5 mb-3">
   <div class="col-lg-8 offset-lg-2">
     <%= form_with model: comment, url: [board, comment] do |f| %>
-      <%= f.text_area :body, class: 'form-control mb-3 outline-black', placeholder: 'コメントを入力', size: "40x10" %>
+      <%= f.text_area :body, class: 'form-control mb-3 outline-black', placeholder: 'コメントを入力', size: "30x8" %>
       <%= f.submit '投稿', class: 'btn btn-primary' %>
     <% end %>
   </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -8,6 +8,16 @@
 
     <%= stylesheet_pack_tag 'application', media: 'all' %>
     <%= javascript_pack_tag 'application' %>
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-S3XP2FR3L3"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-S3XP2FR3L3');
+    </script>
   </head>
 
   <body>

--- a/app/views/likes/_like.html.erb
+++ b/app/views/likes/_like.html.erb
@@ -2,12 +2,12 @@
 <!--「いいね」をしている<p>いいね！</p>場合としていない場合でif文作成-->
 <% if current_user.likes.find_by(board_id: board.id) %>
   <%= link_to board_likes_path(board.id), method: :delete, remote: true do %>
-    <i class="fas fa-thumbs-up"></i>
+    <i class="fas fa-heart"></i>
     <%= board.likes.count %>
   <% end %>
 <% else %>
   <%= link_to board_likes_path(board.id), method: :post, remote: true do %>
-    <i class="far fa-thumbs-up"></i>
+    <i class="far fa-heart"></i>
     <%= board.likes.count %>
   <% end %>
 <% end %>

--- a/app/views/likes/_like.html.erb
+++ b/app/views/likes/_like.html.erb
@@ -1,13 +1,18 @@
 
 <!--「いいね」をしている<p>いいね！</p>場合としていない場合でif文作成-->
-<% if current_user.likes.find_by(board_id: board.id) %>
-  <%= link_to board_likes_path(board.id), method: :delete, remote: true do %>
-    <i class="fas fa-heart"></i>
-    <%= board.likes.count %>
+<% if logged_in? %>
+  <% if current_user.likes.find_by(board_id: board.id) %>
+    <%= link_to board_likes_path(board.id), method: :delete, remote: true do %>
+      <i class="fas fa-heart"></i>
+      <%= board.likes.count %>
+    <% end %>
+  <% else %>
+    <%= link_to board_likes_path(board.id), method: :post, remote: true do %>
+      <i class="far fa-heart"></i>
+      <%= board.likes.count %>
+    <% end %>
   <% end %>
 <% else %>
-  <%= link_to board_likes_path(board.id), method: :post, remote: true do %>
-    <i class="far fa-heart"></i>
-    <%= board.likes.count %>
-  <% end %>
+  <i class="far fa-heart"></i>
+  <%= board.likes.count %>
 <% end %>

--- a/app/views/profiles/edit.html.erb
+++ b/app/views/profiles/edit.html.erb
@@ -4,18 +4,36 @@
       プロフィール編集ページ
     </div>
     <%= form_with model: @user, url: profiles_path, local: true do |f| %>
-      <%= f.label :image %>
-      <%= f.file_field :image, id: "image" %>
+      <% if @user.errors.any? %>
+        <div class="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded relative" role="alert">
+          <strong class="font-bold">
+            <%= render 'shared/error_messages', object: f.object %>
+          </strong>
+        </div>
+      <% end %>
+      <div>
+        <%= f.label :image %>
+        <%= f.file_field :image, id: "image" %>
         <div id="new-image"></div>
-      <%= f.label :name %>
-      <%= f.text_field :name %>
-      <p class= "text-sm text-gray-400">例：ほげぽん</p>
-
-      <%= f.label :email %>
-      <%= f.text_field :email %>
-      <p class= "text-sm text-gray-400">例：music@example.com</p>
-
-      <%= f.submit %>
+      </div>
+      <div>
+        <%= f.label :name, class: "text-gray-700" %>
+        <div class="relative">
+          <div class="inline-flex items-center justify-center absolute left-0 top-0 h-full w-10 text-gray-400">
+            <i class="fas fa-user text-gray-500"></i>
+          </div>
+        <%= f.text_field :name, class: "py-2 pl-10 border border-gray-200 w-full" %>
+      </div>
+      <div>
+        <%= f.label :email, class: "text-gray-700" %>
+          <svg xmlns="http://www.w3.org/2000/svg" class="font-medium text-2xl text-gray-600 absolute p-2.5 px-3 w-11" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M16 12a4 4 0 10-8 0 4 4 0 008 0zm0 0v1.5a2.5 2.5 0 005 0V12a9 9 0 10-9 9m4.5-1.206a8.959 8.959 0 01-4.5 1.207" />
+          </svg>
+        <%= f.text_field :email, class: "py-2 pl-10 border border-gray-200 w-full" %>
+      </div>
+      <div class= "flex flex-row justify-center items-center mt-3">
+        <%= f.submit "更新する", class: "border border-gray-200 hover:bg-gray-200 hover:text-white duration-100 ease-in-out text-black p-2 flex flex-row justify-center items-center cursor-pointer"%>
+      </div>
     <% end %>
   </div>
 </div>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -7,15 +7,14 @@
   <div>
     <ul class="navbar-nav">
       <li class="nav-item m-2">
-        使い方
         <% if logged_in? %>
-          <%= link_to "新規投稿", search_boards_path %>
-          <%= link_to "投稿一覧", boards_path %>
-          <%= link_to "プロフィール", profiles_path %>
-          <%= link_to "ログアウト", logout_path, method: :delete %>
+          <%= link_to "新規投稿", search_boards_path, class: "inline-block text-sm px-4 py-2 leading-none border rounded border-black hover:border-transparent hover:text-teal hover:bg-white mt-4 lg:mt-0" %>
+          <%= link_to "投稿一覧", boards_path, class: "inline-block text-sm px-4 py-2 leading-none border rounded border-black hover:border-transparent hover:text-teal hover:bg-white mt-4 lg:mt-0" %>
+          <%= link_to "プロフィール", profiles_path, class: "inline-block text-sm px-4 py-2 leading-none border rounded border-black hover:border-transparent hover:text-teal hover:bg-white mt-4 lg:mt-0" %>
+          <%= link_to "ログアウト", logout_path, method: :delete, class: "inline-block text-sm px-4 py-2 leading-none border rounded border-black hover:border-transparent hover:text-teal hover:bg-white mt-4 lg:mt-0" %>
         <% else %>
-          <%= link_to "新規登録", new_user_path %>
-          <%= link_to "ログイン", login_path %>
+          <%= link_to "新規登録", new_user_path, class: "inline-block text-sm px-4 py-2 leading-none border rounded border-black hover:border-transparent hover:text-teal hover:bg-white mt-4 lg:mt-0" %>
+          <%= link_to "ログイン", login_path, class: "inline-block text-sm px-4 py-2 leading-none border rounded border-black hover:border-transparent hover:text-teal hover:bg-white mt-4 lg:mt-0" %>
         <% end %>
       </li>
     </ul>

--- a/app/views/user_sessions/new.html.erb
+++ b/app/views/user_sessions/new.html.erb
@@ -21,8 +21,8 @@
             </svg>
           <%= f.password_field :password, class: "py-2 pl-10 border border-gray-200 w-full", placeholder: "Password" %>
         </div>
-        <div>
-          <%= f.submit "ログインする", class: "border border-indigo-500 hover:bg-indigo-500 hover:text-white duration-100 ease-in-out text-indigo-500 p-2 flex flex-row justify-center items-center gap-1" %>
+        <div class= "flex flex-row justify-center items-center mt-3">
+          <%= f.submit "ログインする", class: "border border-gray-200 hover:bg-gray-200 hover:text-white duration-100 ease-in-out text-black p-2 flex flex-row justify-center items-center cursor-pointer" %>
         </div>
       <% end %>
 

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -43,7 +43,7 @@
           <%= f.password_field :password_confirmation, class: "py-2 pl-10 border border-gray-200 w-full", placeholder: "Password confirmation" %>
         </div>
         <div class= "flex flex-row justify-center items-center mt-3">
-          <%= f.submit "登録", class: "border border-gray-200 hover:bg-gray-200 hover:text-white duration-100 ease-in-out text-black p-2 flex flex-row justify-center items-center cursor-pointer" %>
+          <%= f.submit "登録する", class: "border border-gray-200 hover:bg-gray-200 hover:text-white duration-100 ease-in-out text-black p-2 flex flex-row justify-center items-center cursor-pointer" %>
         </div>
       <% end %>
     </div>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -42,7 +42,9 @@
             </svg>
           <%= f.password_field :password_confirmation, class: "py-2 pl-10 border border-gray-200 w-full", placeholder: "Password confirmation" %>
         </div>
-        <%= f.submit "登録する", class: "border border-indigo-500 hover:bg-indigo-500 hover:text-white duration-100 ease-in-out text-indigo-500 p-2 flex flex-row justify-center items-center gap-1" %>
+        <div class= "flex flex-row justify-center items-center mt-3">
+          <%= f.submit "登録", class: "border border-gray-200 hover:bg-gray-200 hover:text-white duration-100 ease-in-out text-black p-2 flex flex-row justify-center items-center cursor-pointer" %>
+        </div>
       <% end %>
     </div>
       <div class="my-2 flex flex-row justify-center">

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,7 +1,7 @@
 <section class="min-h-screen max-w-6xl mx-auto px-4 sm:px-6 lg:px-4 py-12">
   <div class="text-center pb-12">
     <h1 class="font-bold text-3xl md:text-4xl lg:text-5xl font-heading text-white">
-      <%= @user.name %>さんの投稿一覧
+      <%= @user.name %>
     </h1>
   </div>
 
@@ -32,7 +32,7 @@
   <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-3 gap-6">
     <% @boards.each do |board| %>
       <div class="w-full bg-white rounded-lg sahdow-lg p-10 flex flex-col justify-center items-center">
-        <p class="text-xl font-bold mb-3">
+        <p class="text-3xl font-bold mb-3">
           『<%= link_to board.title, board_path(board) %>』
         </p>
         <% if board.board_image.present? %>

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -9,6 +9,7 @@ ja:
         email: メールアドレス
         password: パスワード
         password_confirmation: パスワード確認
+        image: 画像
       board:
         title: タイトル
         body: 内容

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -3,6 +3,9 @@ module.exports = {
   darkMode: false,
   theme: {
     extend: {
+      outline: {
+        black: '2px solid #0f172a',
+      },
       colors: {
         success: {
           // Sky


### PR DESCRIPTION
## issue
https://github.com/wataru-pgm/Recollection_Music/issues/74

## やったこと
710b5fe33f1fadebe4c8dcae6d53347658f7aada
- Google Analyticsを設定しました。
- 投稿詳細ページのレイアウトを修正しました。

a60a01320e950d37452a78c6fe38072e9be4d227
- 投稿編集ページのレイアウトを修正しました。

1e4228060295b242649a427eca1f36770452fe5a
- ヘッダーのレイアウトを修正しました。

08616aa73b75e118ff331edde0b28affdb0d41b7
- ユーザ登録/ログインページのレイアウトを修正しました。


[65a990b](https://github.com/wataru-pgm/Recollection_Music/pull/78/commits/65a990b1a0968824432f4b03953f2007f480e02a)
- 画像をリサイズして表示されるようにしました。

[2d8adfc](https://github.com/wataru-pgm/Recollection_Music/pull/78/commits/2d8adfc9113d4a1a181382e352f773740023c196)
- プロフィール編集ページのレイアウトを修正しました。

[c7c19bb](https://github.com/wataru-pgm/Recollection_Music/pull/78/commits/c7c19bb7b5e61f9343ff0f34ad926b810bfe9a82)
- fontawsomeを変更しました。

[6a34d9c](https://github.com/wataru-pgm/Recollection_Music/pull/78/commits/6a34d9c2e8823b46f281942a43839b2cea3280ac)
- 非ログイン状態でも投稿詳細ページが見れるように変更しました。